### PR TITLE
ADD: Getting started guide - restructure (#96)

### DIFF
--- a/.github/workflows/build-book-pullrequest.yaml
+++ b/.github/workflows/build-book-pullrequest.yaml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 env:
-  DOCKER_TAG: pr_84
+  DOCKER_TAG: pr_96
 
 jobs:
   build-book:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -25,7 +25,7 @@ on:
         type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
 
 env:
-  DOCKER_TAG: pr_84
+  DOCKER_TAG: pr_96
 
 jobs:
   build-container:

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/openradar/erad2024:pr_84
+FROM ghcr.io/openradar/erad2024:pr_96

--- a/getting_started.md
+++ b/getting_started.md
@@ -1,0 +1,31 @@
+# Notebook Execution
+
+There are two options to work with this course, via Project Pythia Hub and locally on your machine.
+
+## Project Pythia Hub
+
+Just use the `enable computing` button within a notebook on this site to run each cell individually, rendering the output immediately to html.
+A second option, and the preferred one for this course is to fire up a jupyterlab instance on the Project Pythia Hub via the [Launch Environment](https://binder.projectpythia.org/v2/gh/openradar/erad2024/main?labpath=notebooks)-Button
+on the top right navigation bar. You'll find yourself in the well known jupyterlab environment, ready to do some science.
+
+## Locally on your own premises
+
+The easiest is to make use of our pre-built docker image which includes all the needed bits and pieces and is actually also
+used as base image for the Project Pythia Hub instance.
+
+The only thing you need is a running docker service on your local machine.
+
+Then it's just a one-liner:
+
+```bash
+$ docker run -ti --name erad2024 -p 8888:8888 -e LOCAL_USER_ID=$UID ghcr.io/openradar/erad2024:latest /srv/conda/envs/notebook/bin/jupyter lab --ip='*' --port=8888
+```
+Some of the notebooks are utilizing quite some large cloud data files. So a decent network connection (LAN connection) is preferred to make use of those notebooks.
+Don't try this at the course as bandwidth will be limited.
+
+If you need a connection to the outside world, you can mount local folders and environment variables into the running container. Please check out the [docker documentation](https://docs.docker.com/guides/use-case/jupyter/) for more details
+
+```bash
+$ docker run -ti --name erad2024 -p 8888:8888 -v /host/path/to/your/folder:/home/your/folder -e LOCAL_USER_ID=$UID -e YOUR_ENV_VAR=your_env_var ghcr.io/openradar/erad2024:latest /srv/conda/envs/notebook/bin/jupyter lab --ip='*' --port=8888
+
+```

--- a/myst.yml
+++ b/myst.yml
@@ -58,9 +58,11 @@ project:
     - title: Schedule
       children:
         - file: schedule.md
-    - title: Data Access
+    - title: Getting started
       children:
+        - file: getting_started.md
         - file: notebooks/data-access/intro-data-access.ipynb
+        - file: notebooks/environment.ipynb
     - title: Radar Software Foundations
       children:
         - title: XRadar
@@ -81,9 +83,6 @@ project:
         - title: LROSE
           children:
             - file: notebooks/lrose/lrose-introduction.ipynb
-    - title: Notebook Environment
-      children:
-        - file: notebooks/environment.ipynb
     - title: Retrieving winds with PyDDA
       children:
         - file: notebooks/Retrieving_winds_with_pydda.ipynb


### PR DESCRIPTION
* Add Getting started guide with docker instructions
* Restructure
* tag docker

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a 'Getting Started' guide with Docker instructions, restructure the documentation to include this new section, and update CI workflows with a new Docker tag.

New Features:
- Introduce a 'Getting Started' guide with instructions for using Docker to set up the environment.

Enhancements:
- Restructure the documentation by adding a 'Getting Started' section and reorganizing existing content.

CI:
- Update the Docker tag in the CI workflows to 'pr_96' for both build-book-pullrequest and build-book workflows.

Documentation:
- Add a new 'getting_started.md' file providing detailed instructions on executing notebooks via Project Pythia Hub and locally using Docker.

<!-- Generated by sourcery-ai[bot]: end summary -->